### PR TITLE
Make docere executable as a module or entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ Docere is a workflow and set of tools for publishing data analyses.
 
 Docere sounds like "dose air"
 
+# Installation
+
+Docere is hosted on PyPI, so is installable via `pip`:
+
+    pip install docere
+
+Once installed, see usage details via:
+
+    docere --help
+    docere render --help
+
 # Design Principles
 
 * Analysts should have total control of their report presentation

--- a/docere/__main__.py
+++ b/docere/__main__.py
@@ -1,0 +1,9 @@
+from docere import cli
+
+
+def main(args=None):
+    cli.cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,11 @@ setup(
     author_email='harterrt@mozilla.com',
     url='https://github.com/harterrt/docere.git',
     packages=find_packages(exclude=['tests']),
+    entry_points={
+        'console_scripts': [
+            'docere = docere.cli:cli'
+        ]
+    },
     include_package_data=True,
     install_requires=[
         'pyfunctional',


### PR DESCRIPTION
Adding `__main__.py` enables invoking docere as:

    python -m docere render

Adding `entry_points` in `setup.py` enables invoking docere as:

    docere render