### PR TITLE
Support 'authors' in addition to 'author' in report.json

### DIFF
--- a/docere/plugins/index/templates/body.html
+++ b/docere/plugins/index/templates/body.html
@@ -20,7 +20,7 @@
         <a href="{{report.path}}">{{report.title}}</a>
       </td>
       <td>
-        {{report.author}}
+        {{report.author}}{{ report.authors|join(', ') }}
       </td>
       <td>
         {{report.publish_date}}


### PR DESCRIPTION
Existing RTMO reports have plural authors rather than singular. This allows either to render on the docere index page.