### PR TITLE
Test on recent Pythons

### DIFF
--- a/docere/render.py
+++ b/docere/render.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from functional import seq
 from shutil import copytree, rmtree
 from contextlib import contextmanager
 from .plugins.index import build_index
@@ -38,13 +37,10 @@ def _load_report_config(directory):
 
 
 def _get_reports(path='.'):
-    return (
-        seq(os.walk(path))
-        .map(lambda d: Directory(*d))
-        .filter(lambda d: REPORT_CONFIG_FILE in d.filenames)
-        .map(_load_report_config)
-        .to_list()
-    )
+    dirs = (Directory(*d) for d in os.walk(path))
+    with_config = (d for d in dirs if REPORT_CONFIG_FILE in d.filenames)
+    reports = [_load_report_config(d) for d in with_config]
+    return reports
 
 
 @contextmanager

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     },
     include_package_data=True,
     install_requires=[
-        'pyfunctional',
         'jinja2',
         'click',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,flake8
+envlist = py37,py38,flake8
 skip_missing_interpreters=true
 
 [pytest]
@@ -11,6 +11,6 @@ extras = testing
 commands = pytest {posargs}
 
 [testenv:flake8]
-basepython = python2.7
+basepython = python3.7
 deps = flake8
 commands = flake8 docere tests --max-line-length=100

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ skip_missing_interpreters=true
 addopts = --cov=docere tests/
 
 [testenv]
-usedevelop = True
 extras = testing
 commands = pytest {posargs}
 


### PR DESCRIPTION
Update the versions of Python we test on.

Also remove pyfunctional since it's throwing deprecation warnings, and exercise the sdist build logic in the tests.